### PR TITLE
Fix indexes related to writing

### DIFF
--- a/indexes/plugin.js
+++ b/indexes/plugin.js
@@ -39,6 +39,9 @@ module.exports = class Plugin {
       if (processedOffset < 0 || this.level.isClosed()) return cb()
       if (!this.onFlush) this.onFlush = (cb2) => cb2()
 
+      const processedOffsetAtFlush = processedOffset
+      const processedSeqAtFlush = processedSeq
+
       this.onFlush((err) => {
         if (err) return cb(err)
 
@@ -53,12 +56,12 @@ module.exports = class Plugin {
             // 2nd, persist the META because it has its own valueEncoding
             this.level.put(
               META,
-              { version, offset: processedOffset, processed: processedSeq },
+              { version, offset: processedOffsetAtFlush, processed: processedSeqAtFlush },
               { valueEncoding: 'json' },
               (err3) => {
                 if (err3) cb(err3)
                 else {
-                  this.offset.set(processedOffset)
+                  this.offset.set(processedOffsetAtFlush)
                   cb()
                 }
               }


### PR DESCRIPTION
While testing partial replication with indexes we found a problem where we received an error saying that the index was there, but the main message was not. These 2 messages are written as a transaction so this should never happen. What happened was a classic concurrency problem where the 2 variables are not fixed in time at the time of writing.