### PR TITLE
make sure that deleteFeed is idempotent and performant

### DIFF
--- a/test/basic.js
+++ b/test/basic.js
@@ -144,7 +144,7 @@ test('getMsg', (t) => {
   })
 })
 
-test('delete single', (t) => {
+test('delete single msg', (t) => {
   const post = { type: 'post', text: 'Testing!' }
 
   db.publish(post, (err, postMsg) => {
@@ -167,7 +167,7 @@ test('delete single', (t) => {
   })
 })
 
-test('delete all', (t) => {
+test('deleteFeed', (t) => {
   const post = { type: 'post', text: 'Testing!' }
   const post2 = { type: 'post', text: 'Testing 2!' }
 
@@ -206,6 +206,13 @@ test('delete all', (t) => {
         }
       )
     })
+  })
+})
+
+test('deleteFeed unknown', (t) => {
+  db.deleteFeed(ssbKeys.generate().id, (err) => {
+    t.error(err, 'no err')
+    t.end()
   })
 })
 


### PR DESCRIPTION
**Context:** I have an idea for deleting blocked feeds in an automatic way: use `ssb-friends` to scan all the blocked feeds and call `deleteFeed` on them. In case those feeds were already deleted, we need to make sure that `deleteFeed` is going to be performant and not cause any bugs.

**Solution:** when clearing the `base` index, this PR now checks first if an entry exists for that `feedId`. If it exists, then we can avoid calling `flush` and `level.del` in vain. 

An important thing to keep in mind is that `deleteFeed` is not atomic. The app may crash in the middle of a `deleteFeed`, meaning that some messages owned by that feed are deleted, but not all of them. So in a sense it's desired to call `deleteFeed` every time the app is opened, to make sure all messages are deleted.

Check more comments I put in the implementation of `deleteFeed` just to explain my points better:

```js
self.query(
  where(author(feedId)),
  asOffsets(),
  toCallback((err, offsets) => {
    if (err) return cb(clarify(err, 'deleteFeed() failed to query jitdb'))
    //
    // if `offsets` is empty, then the push-stream pipe below 
    // skips directly to the collect
    //
    push(
      push.values(offsets),
      push.asyncMap(log.del),
      push.collect((err) => {
        if (err) cb(clarify(err, 'deleteFeed() failed for feed ' + feedId))
        else {
          //
          // this `delete` should be fast
          //
          delete state[feedId]
          //
          // this removeFeedFromLatest should be fast
          //
          indexes.base.removeFeedFromLatest(feedId, cb)
        }
      })
    )
  })
)
```