### PR TITLE
Faster ebt for encrypted messages

### DIFF
--- a/indexes/ebt.js
+++ b/indexes/ebt.js
@@ -5,7 +5,6 @@
 const bipf = require('bipf')
 const clarify = require('clarify-error')
 const Plugin = require('./plugin')
-const { reEncrypt } = require('./private')
 
 const BIPF_AUTHOR = bipf.allocAndEncode('author')
 const BIPF_SEQUENCE = bipf.allocAndEncode('sequence')
@@ -36,19 +35,19 @@ module.exports = class EBT extends Plugin {
       // prettier-ignore
       if (err) return cb(clarify(err, 'EBT.levelKeyToMessage() failed when getting leveldb item'))
       else
-        this.log.get(parseInt(offset, 10), (err, record) => {
+        this.log.getRaw(parseInt(offset, 10), (err, record) => {
           // prettier-ignore
           if (err) return cb(clarify(err, 'EBT.levelKeyToMessage() failed when getting log record'))
-          cb(null, bipf.decode(record, 0))
+          cb(null, record)
         })
     })
   }
 
   // this is for EBT so must be careful to not leak private messages
   getMessageFromAuthorSequence(key, cb) {
-    this.levelKeyToMessage(JSON.stringify(key), (err, msg) => {
+    this.levelKeyToMessage(JSON.stringify(key), (err, record) => {
       if (err) cb(clarify(err, 'EBT.getMessageFromAuthorSequence() failed'))
-      else cb(null, reEncrypt(msg))
+      else cb(null, bipf.decode(record, 0))
     })
   }
 }

--- a/log.js
+++ b/log.js
@@ -71,6 +71,9 @@ module.exports = function (dir, config, privateIndex) {
     })
   }
 
+  // in case you want the encrypted msg
+  log.getRaw = originalGet
+
   // monkey-patch log.stream to temporarily pause when the CPU is too busy,
   // and to decrypt the msg
   const originalStream = log.stream


### PR DESCRIPTION
There is no need to first decrypt the message and then reEncrypt them ;)

There is a test [here](https://github.com/ssbc/ssb-db2/blob/c35306e265ee67b60a87a355a992ebd9880d6f90/test/ebt.js#L78) for that case. Just so we are sure this is not breaking anything.