### PR TITLE
cache decrypted content based on record buffer

### DIFF
--- a/indexes/private.js
+++ b/indexes/private.js
@@ -146,7 +146,11 @@ module.exports = function (dir, sbot, config) {
     return ssbKeys.unbox(ciphertext, keys)
   }
 
+  const contentCache = new WeakMap()
   function tryDecryptContent(ciphertext, recBuffer, pValue) {
+    if (contentCache.has(recBuffer)) {
+      return contentCache.get(recBuffer)
+    }
     let content = ''
     if (ciphertext.endsWith('.box')) {
       content = decryptBox1(ciphertext, config.keys)
@@ -161,6 +165,7 @@ module.exports = function (dir, sbot, config) {
         }
       }
     }
+    contentCache.set(recBuffer, content)
     return content
   }
 

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "operators/*.js"
   ],
   "dependencies": {
-    "async-append-only-log": "^4.2.2",
+    "async-append-only-log": "ssbc/async-append-only-log#record-cache",
     "atomic-file-rw": "^0.2.1",
     "binary-search-bounds": "^2.0.4",
     "bipf": "^1.5.4",


### PR DESCRIPTION
This is a just-FYI PR. I ran unit tests (e.g. `test/private.js`) and confirmed that the cache causes the decryption to be skipped if it has been already done.

In the big picture though, unfortunately it doesn't seem like caching does any difference to performance. In fact in some cases it seems like performance got worse. I don't understand why. :(

I'm leaving this PR here in case I made a dumb mistake somewhere and there would still be hope for this optimization technique.

Numbers below

| Perf test | Before | After|
|----|-----|------|
| add a bunch of messages | 530ms | 530ms |
| box1 | 1132ms | 1125ms |
| unbox first run | 105ms | 115ms |
| unbox second run | 91ms | 89ms |
| private box1 no decrypt, box | 1117ms | 1021ms |
| query first run | 35ms | 30ms |
| query second run | 20ms | 23ms |
| private box2, box | 603ms | 552ms |
| unbox duration first run | 314ms | 313ms |
| unbox duration second run | 315ms | 319ms |
| migrate (alone) | 3928ms | 18515ms |
| migrate (+db2) | 5991ms | 6550ms |
| migrate continuation (+db2) | 742ms | 1097ms |
| migrate (+db1) | 10297ms | 16482ms |
| migrate (+db1 +db2) | 27527ms | 5842ms |
| Memory usage without indexes | 713.67 MB = 36.50 MB + etc | 759.07 MB = 31.53 MB + etc |
| initial indexing | 496ms | 699ms |
| initial indexing maxcup 86% | 5910ms | 5200ms |
| initial indexing compat | 623ms | 1285ms |
| Two indexes updating concurrently | 727ms | 910ms |
| key one initial | 50ms | 352ms |
| key two | 2ms | 3ms |
| key one again | 1ms | 1ms |
| reboot and key one again | 61ms | 352ms |
| latest root posts | 509ms | 612ms |
| latest posts | 12ms | 8ms |
| votes one initial | 468ms | 537ms |
| votes again | 1ms | 1ms |
| hasRoot | 279ms | 384ms |
| hasRoot again | 0ms | 1ms |
| author one posts | 270ms | 280ms |
| author two posts | 17ms | 18ms |
| dedicated author one posts | 258ms | 327ms |
| dedicated author one posts again | 0ms | 1ms |
| maxium RAM used | 813.08 MB = 52.54 MB + etc | 786.40 MB = 52.74 MB + etc |
| Indexes folder size | 9.97 MB | 9.97 MB |