### PR TITLE
Fix restart update indexes

### DIFF
--- a/db.js
+++ b/db.js
@@ -554,8 +554,8 @@ exports.init = function (sbot, config) {
     if (abortLogStreamForIndexes) {
       abortLogStreamForIndexes()
       abortLogStreamForIndexes = null
+      updateIndexes()
     }
-    indexesStateLoaded.onReady(updateIndexes)
   }
 
   function registerIndex(Index) {


### PR DESCRIPTION
While debugging https://github.com/ssbc/ssb-db2/pull/349 I noticed that `restartUpdateIndexes` was behaving a bit unexpectedly. Compaction added a call to restartUpdateIndexes on [startup](https://github.com/ssbc/ssb-db2/blob/f976aac9a4bd4ee804b9f4cd24511dec52cb5d9d/db.js#L840) even if there was nothing to do. This means that if you have an empty database both the normal updateIndexes call, but also the updateIndexes call from restartUpdateIndexes would be queued up for when indexesStateLoaded is ready. This means that you will get 2 calls right after another one calling the other. What this change does it to only call updateIndexes if abortLogStreamForIndexes is set. Meaning that updateIndexes are already running and it will be stopped because we abort those log streams.