### PR TITLE
status() is reset after compaction

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -27,7 +27,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 16.x]
+        node-version: [16.x]
 
     steps:
       - uses: actions/checkout@v2
@@ -46,10 +46,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Use Node.js 12.x
+      - name: Use Node.js 16.x
         uses: actions/setup-node@v1
         with:
-          node-version: 12.x
+          node-version: 16.x
       - run: npm install
       - name: Benchmark
         run: npm run benchmark

--- a/test/compaction.js
+++ b/test/compaction.js
@@ -197,11 +197,18 @@ test('post-compaction reindex resets state in memory too', async (t) => {
   await pify(sbot.db.del)(msg2.key)
   t.pass('deleted description about')
 
+  const offsetBefore = sbot.db.getStatus().value.log
+  t.true(offsetBefore > 0, 'log offset is > 0')
+  t.equals(sbot.db.getStatus().value.indexes.base, offsetBefore, 'status for base index is latest offset')
+
   await pify(sbot.db.compact)()
   t.pass('compacted the log')
 
-  await pify(setTimeout)(1000)
+  t.equals(sbot.db.getStatus().value.indexes.base, -1, 'status for base index is -1')
 
+  await pify(setTimeout)(2000)
+
+  t.equals(sbot.db.getStatus().value.indexes.base, offsetBefore, 'status for base index is latest offset')
   const profileAfter = sbot.db.getIndex('aboutSelf').getProfile(author.id)
   t.equal(profileAfter.name, 'Alice')
   t.notOk(profileAfter.description)


### PR DESCRIPTION
## Context

I'm putting compaction in Manyverse and realized that the progress bars were quite funky (going backwards sometimes).

## Problem

#354 

> `Status` is stateful (particularly with leveldb indexes) and may make the calculation of progress bars become incorrect. We should reset it.

## Solution

Add a new method `reset()` to `status` which puts the numbers as they were at initialization.

1st :x: 2nd :heavy_check_mark: 