### PR TITLE
fix Plugin.reset() logic to update offset

### DIFF
--- a/indexes/plugin.js
+++ b/indexes/plugin.js
@@ -143,11 +143,11 @@ module.exports = class Plugin {
     const subClassReset = this.reset
     this.reset = (cb) => {
       if (subClassReset) subClassReset.call(this)
+      this.batch = []
+      this.offset.set(-1)
       this.level.clear(() => {
         processedSeq = 0
         processedOffset = -1
-        this.batch = []
-        this.offset.set(-1)
         cb()
       })
     }

--- a/test/compaction.js
+++ b/test/compaction.js
@@ -206,7 +206,7 @@ test('post-compaction reindex resets state in memory too', async (t) => {
 
   t.equals(sbot.db.getStatus().value.indexes.base, -1, 'status for base index is -1')
 
-  await pify(setTimeout)(2000)
+  await pify(sbot.db.onDrain)('aboutSelf')
 
   t.equals(sbot.db.getStatus().value.indexes.base, offsetBefore, 'status for base index is latest offset')
   const profileAfter = sbot.db.getIndex('aboutSelf').getProfile(author.id)


### PR DESCRIPTION
## Context

Working on putting compaction, deletes, truncation in Manyverse and noticed some issues related to compaction, such as

## Problem

#355 

## Solution

Update an index's `offset` obz as soon as reset() is called, so that subsequent onDrain() calls for that index use the updated `offset` value to know whether or not the indexing has completed.

1st :x: 2nd :heavy_check_mark: 