### PR TITLE
test that live fullMentions is silent during reindexing

### DIFF
--- a/test/delete-feed.js
+++ b/test/delete-feed.js
@@ -13,7 +13,8 @@ const SecretStack = require('secret-stack')
 const caps = require('ssb-caps')
 const generateFixture = require('ssb-fixtures')
 const fs = require('fs')
-const { where, author, toPromise } = require('../operators')
+const { where, live, author, toPromise, toPullStream } = require('../operators')
+const mentions = require('../operators/full-mentions')
 
 const dir = '/tmp/ssb-db2-delete-feed-compact'
 
@@ -43,6 +44,7 @@ test('delete a feed and then compact', async (t) => {
   const keys = ssbKeys.loadOrCreateSync(path.join(dir, 'secret'))
   const sbot = SecretStack({ appKey: caps.shs })
     .use(require('../'))
+    .use(require('../full-mentions'))
     .call(null, {
       keys,
       path: dir,
@@ -60,6 +62,22 @@ test('delete a feed and then compact', async (t) => {
       })
     )
   })
+
+  let gotSpecialMention = false
+  pull(
+    sbot.db.query(where(mentions(sbot.id)), live(), toPullStream()),
+    pull.drain((msg) => {
+      if (msg.value.content.special) {
+        if (gotSpecialMention) {
+          t.fail('got more than one special mention')
+        } else {
+          gotSpecialMention = true
+        }
+      } else {
+        t.fail('should not get any live mentions during reindexing')
+      }
+    })
+  )
 
   const badPerson = '@a5URnr0bEtVFmNxQu/JwQ5JsfEl+HAPz5ethL+I1CCA=.ed25519'
   t.notEqual(sbot.id, badPerson, 'I am not the bad person')
@@ -95,6 +113,17 @@ test('delete a feed and then compact', async (t) => {
 
   const msgsBad2 = await sbot.db.query(where(author(badPerson)), toPromise())
   t.equals(msgsBad2.length, 0, 'zero messages by bad person')
+
+  await pify(sbot.db.publishAs)(ssbKeys.generate(), {
+    type: 'post',
+    text: 'Hi',
+    special: 'yes',
+    mentions: [{ link: sbot.id }],
+  })
+  t.pass('published new mention')
+
+  await pify(setTimeout)(1000)
+  t.true(gotSpecialMention, 'got special mention')
 
   await pify(sbot.close)(true)
   t.end()


### PR DESCRIPTION
## Context

When running deleteFeed-and-compact-and-reindex in Manyverse, I noticed that the Activity tab highlighted as "new", which didn't make sense because there was no new content added (replication was turned off).

This happened consistently, regardless of what dataset I was using (production or ssb-fixtures).

See also https://github.com/ssbc/ssb-db2/issues/306#issuecomment-1161950044

## Problem

It turned out the problem was with leveldb live. The way that `pull-level` and `level-post` work is by adding listeners to the leveldb EventEmitter `'put'`, `'del`', `'batch'`: https://github.com/dominictarr/level-post/blob/9021f153f159aa1d13233908ebe616f650e78f22/index.js#L44-L46

Obviously, during reindexing, we use `batch` to recreate the index, and this triggers the "live" side of pull-level, which then triggers [fullMentions live stream](https://github.com/ssbc/ssb-db2/blob/f31203a39060d9b46d608592762d9007cc21eac3/indexes/full-mentions.js#L71). The Activity tab in Manyverse uses fullMentions. But I also think that any other leveldb index which uses live, such as aboutSelf, would be affected in a similar way.

## Solution

Not the cleanest solution, but I wanted to find a solution that is general for all our leveldb indexes AND contained to ssb-db2 repo and not requiring each index to be updated.

I figured that we can just rip out all the EventEmitter listeners when the leveldb index is "reset" (which so far ONLY happens after compaction), and then wait until the index catches up with the full log, and then put those listeners back in.

1st :x: 2nd :heavy_check_mark: 