### PR TITLE
fix migrate: close newLog when there  is no ssb-db2 installed

### DIFF
--- a/migrate.js
+++ b/migrate.js
@@ -208,6 +208,7 @@ exports.init = function init(sbot, config) {
   function oldLogMissingThenRetry(retryFn) {
     if (!hasCloseHook) {
       sbot.close.hook(function (fn, args) {
+        stop()
         if (!sbot.db && newLog) {
           newLog.close(() => {
             fn.apply(this, args)

--- a/test/migration-alone.js
+++ b/test/migration-alone.js
@@ -49,16 +49,15 @@ test('migrate (alone) moves msgs from old log to new log', (t) => {
     pull.filter((x) => x === 1),
     pull.take(1),
     pull.collect((err) => {
-      t.error(err)
-      setTimeout(() => {
+      t.error(err, 'no error when migration is done')
+      sbot.close(true, () => {
+        t.pass('sbot closed')
         t.true(
           fs.existsSync(path.join(dir, 'db2', 'log.bipf')),
-          'migration done'
+          'migration created log.bipf file'
         )
-        sbot.close(() => {
-          t.end()
-        })
-      }, 1000)
+        t.end()
+      })
     })
   )
 })


### PR DESCRIPTION
## Context

I was testing Manyverse, and noticed that right after it migrates `~/.ssb` to ssb-db2 (using `ssb-db2/migrate` *without* the rest of ssb-db2), indexing would not happen at all, the app seemed totally blank without content. On a second run of the app, indexing happens and content appears.

## Problem

When using the migrate plugin alone, without ssb-db2, then the `sbot.close` hook does **not** run `log.close` (which should make sure all writes are done). This meant that `sbot.close` callbacks were called *before* AAOL was reading writing to disk.

## Solution

ssb-db2/db.js already handles this case correctly, so we only need to patch the case where we are running `.use(require('ssb-db2/migrate'))` without `.use(require('ssb-db'))`, such that the close hook calls `log.close`.

1st :x: 2nd :heavy_check_mark: 