### PR TITLE
Test performance of a large number of group keys

### DIFF
--- a/benchmark/index.js
+++ b/benchmark/index.js
@@ -337,14 +337,19 @@ test('private box1 no decrypt', (t) => {
 
   const recps = [...randos, keys.id]
 
-  let contents = []
+  let opts = []
   for (var i = 0; i < 1000; ++i)
-    contents.push({ type: 'tick', count: i, recps: shuffle(recps) })
+    opts.push({
+      feedFormat: 'classic',
+      content: { type: 'tick', count: i },
+      recps: shuffle(recps),
+      encryptionFormat: 'box'
+    })
 
   startMeasure(t, 'add 1000 box1 msgs')
   pull(
-    pull.values(contents),
-    pull.asyncMap(sbot.db.publish),
+    pull.values(opts),
+    pull.asyncMap(sbot.db.create),
     pull.collect((err, msgs) => {
       endMeasure(t, 'add 1000 box1 msgs')
       if (err) t.fail(err)
@@ -389,14 +394,19 @@ test('private box2', (t) => {
   )
   sbot.box2.addOwnDMKey(testkey)
 
-  let contents = []
+  let opts = []
   for (var i = 0; i < 1000; ++i)
-    contents.push({ type: 'tick', count: i, recps: shuffle(recps) })
+    opts.push({
+      feedFormat: 'classic',
+      content: { type: 'tick', count: i },
+      recps: shuffle(recps),
+      encryptionFormat: 'box2'
+    })
 
   startMeasure(t, 'add 1000 box2 msgs')
   pull(
-    pull.values(contents),
-    pull.asyncMap(sbot.db.publish),
+    pull.values(opts),
+    pull.asyncMap(sbot.db.create),
     pull.collect((err, msgs) => {
       endMeasure(t, 'add 1000 box2 msgs')
       if (err) t.fail(err)
@@ -460,7 +470,7 @@ test('private box2 group keys', (t) => {
 
   t.pass(`Group keys: ${groups}, percentage for me: ${percentMe}%`)
 
-  let contents = []
+  let opts = []
   for (var i = 0; i < 1000; ++i) {
     const percentage = Math.floor(Math.random() * 100)
     const groupId = Math.floor(Math.random() * groups)
@@ -468,13 +478,18 @@ test('private box2 group keys', (t) => {
 
     // group must be first
     const recps = [group]
-    contents.push({ type: 'tick', count: i, recps })
+    opts.push({
+      feedFormat: 'classic',
+      content: { type: 'tick', count: i },
+      recps: recps,
+      encryptionFormat: 'box2'
+    })
   }
 
   startMeasure(t, 'add 1000 box2 group msgs')
   pull(
-    pull.values(contents),
-    pull.asyncMap(sbot.db.publish),
+    pull.values(opts),
+    pull.asyncMap(sbot.db.create),
     pull.collect((err, msgs) => {
       endMeasure(t, 'add 1000 box2 group msgs')
       if (err) t.fail(err)

--- a/encryption-formats/box2.js
+++ b/encryption-formats/box2.js
@@ -37,6 +37,10 @@ function makeKeysManager(config) {
     groupKeysCache.set(id, key)
   }
 
+  function removeGroupKey(id) {
+    groupKeysCache.delete(id)
+  }
+
   function groupKey(id) {
     if (groupKeysCache.has(id)) {
       return { key: groupKeysCache.get(id), scheme: keySchemes.private_group }
@@ -58,6 +62,7 @@ function makeKeysManager(config) {
     sharedDMKey,
 
     addGroupKey,
+    removeGroupKey,
     groupKey,
     groupKeys,
   }
@@ -96,6 +101,10 @@ module.exports = {
 
       _addGroupKey(id, key) {
         encryptionFormat._keysManager.addGroupKey(id, key)
+      },
+
+      _removeGroupKey(id, key) {
+        encryptionFormat._keysManager.removeGroupKey(id, key)
       },
 
       encrypt(plaintextBuf, opts) {
@@ -202,6 +211,7 @@ module.exports = {
     return {
       addOwnDMKey: encryptionFormat._addOwnDMKey,
       addGroupKey: encryptionFormat._addGroupKey,
+      removeGroupKey: encryptionFormat._removeGroupKey,
     }
   },
 }


### PR DESCRIPTION
This PR came out of a discussion about how box2 behaves when you are in a large number of groups. We decided to test this and to use this inform us about how we should go about decrypting group messages. The current strategy is to just try all keys in whatever order they were added. If you are in 1000 groups, then unboxing 1000 box2 messages takes around 30s. This is with 30% of the messages matching a group you are a part of (in other words, for 70% of the messages you try all 1000 keys in vain). The scaling is roughly linear, so 100 groups is ~3s.

Mix had an idea to use membership information to only try group keys that we know the author feed is a part of. This should provide a nice performance boost as you try a lot less keys, but complicates reindexing because you need a bit more state.

Another optimization we could do, that can also be combined with the above, is to sort the keys based on when they last decrypted a message the last time. If you are in a 1000 groups, then a lot of these are probably not super active. As soon as you decrypt the message you are done, so the order really matters.