### PR TITLE
dont allow queries to start when compact() just started

### DIFF
--- a/db.js
+++ b/db.js
@@ -816,6 +816,7 @@ exports.init = function (sbot, config) {
     fs.closeSync(fs.openSync(resetLevelPath(dir), 'w'))
     fs.closeSync(fs.openSync(resetPrivatePath(dir), 'w'))
     fs.closeSync(fs.openSync(reindexJitPath(dir), 'w'))
+    compacting.set(true)
     log.compact(function onLogCompacted(err) {
       if (err) cb(clarify(err, 'ssb-db2 compact() failed with the log'))
       else cb()

--- a/db.js
+++ b/db.js
@@ -813,10 +813,10 @@ exports.init = function (sbot, config) {
     if (notYetZero(jitdb.queriesActive, compact, cb)) return
     if (notYetZero(indexingActive, compact, cb)) return
 
+    compacting.set(true)
     fs.closeSync(fs.openSync(resetLevelPath(dir), 'w'))
     fs.closeSync(fs.openSync(resetPrivatePath(dir), 'w'))
     fs.closeSync(fs.openSync(reindexJitPath(dir), 'w'))
-    compacting.set(true)
     log.compact(function onLogCompacted(err) {
       if (err) cb(clarify(err, 'ssb-db2 compact() failed with the log'))
       else cb()

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "operators/*.js"
   ],
   "dependencies": {
-    "async-append-only-log": "^4.2.7",
+    "async-append-only-log": "^4.3.1",
     "atomic-file-rw": "^0.3.0",
     "binary-search-bounds": "^2.0.4",
     "bipf": "^1.5.4",
@@ -26,7 +26,7 @@
     "flumecodec": "0.0.1",
     "flumelog-offset": "3.4.4",
     "hoox": "0.0.1",
-    "jitdb": "^6.6.3",
+    "jitdb": "^6.6.4",
     "level": "^6.0.1",
     "level-codec": "^9.0.2",
     "lodash.debounce": "^4.0.8",


### PR DESCRIPTION
## Problem

`compacting` is set to true only when `compactionProgress` reports something, but that could take a while (it needs to write a block in AAOL), and in the meantime, someone could call `ssb.db.query`, which can proceed if `compacting === false`.

## Solution

As soon as we call `compact()`, set `compacting` to true.

1st :x: 2nd :heavy_check_mark: 