### PR TITLE
wait for encryption formats to load before encrypting

### DIFF
--- a/utils.js
+++ b/utils.js
@@ -26,6 +26,12 @@ function onceWhen(obv, filter, cb) {
   })
 }
 
+function onceWhenPromise(obv, filter) {
+  return new Promise((resolve) => {
+    onceWhen(obv, filter, resolve)
+  })
+}
+
 class ReadyGate {
   constructor() {
     this.waiting = new Set()
@@ -44,4 +50,4 @@ class ReadyGate {
   }
 }
 
-module.exports = { onceWhen, ReadyGate }
+module.exports = { onceWhen, onceWhenPromise, ReadyGate }


### PR DESCRIPTION
**Problem:** our `./encryption-formats/box2.js` `setup()` was actually not asynchronous, it was sync. Because of this, you could always call any of its APIs at any time, and it would work. Add a simple `setTimeout(1000` and then it doesn't work anymore.

The deeper problem is that in `indexes/private.js` we load the index files and if there is an error (and there often is, because the index files are non-existent) then the *other* computation (such as loading encryption formats) is cancelled. This is a normal behavior of errors in JS, and `multicb` does it too: if there is an error anywhere, stop everything.

But what we really want is: if there is an error when loading private indexes, that's okay, please proceed async loading the encryption formats too.

**Solution:** in `indexes/private`, treat loadFile errors as "callback results", not as errors, and treat encryptionFormats.setup errors as critical (which they are). Simulate async in `encryption-formats/box2.js`, and then also make sure that `create()` waits for private indexes (and thus encryption formats) to load before proceeding to encrypt.