### PR TITLE
bring back isPrivate() operator

### DIFF
--- a/operators/index.js
+++ b/operators/index.js
@@ -21,7 +21,7 @@ const {
   seekMetaEncryptionFormat,
   seekContent,
 } = require('../seekers')
-const { and, seqs, equal, predicate, includes, offsets, deferred } =
+const { and, or, seqs, equal, predicate, includes, offsets, deferred } =
   jitdbOperators
 
 function key(msgId) {
@@ -192,6 +192,10 @@ function isEncrypted(encryptionFormat) {
   }
 }
 
+function isPrivate(encryptionFormat) {
+  return or(isEncrypted(encryptionFormat), isDecrypted(encryptionFormat))
+}
+
 module.exports = Object.assign({}, jitdbOperators, {
   type,
   author,
@@ -209,4 +213,5 @@ module.exports = Object.assign({}, jitdbOperators, {
   isPublic,
   isDecrypted,
   isEncrypted,
+  isPrivate,
 })

--- a/test/operators.js
+++ b/test/operators.js
@@ -18,6 +18,7 @@ const {
   type,
   isDecrypted,
   isEncrypted,
+  isPrivate,
   isPublic,
   toCallback,
   author,
@@ -294,6 +295,18 @@ test('execute isEncrypted(box2)', (t) => {
     toCallback((err, msgs) => {
       t.error(err, 'no err')
       t.equal(msgs.length, 0)
+      t.end()
+    })
+  )
+})
+
+
+test('execute isPrivate()', (t) => {
+  db.query(
+    where(isPrivate()),
+    toCallback((err, msgs) => {
+      t.error(err, 'no err')
+      t.equal(msgs.length, 2)
       t.end()
     })
   )


### PR DESCRIPTION
For issue #374. I noticed that I would just use `or(isEncrypted(), isDecrypted())` and that's a bit verbose so we can just have a shortcut.

See https://github.com/ssbc/ssb-subset-ql/blob/1f99976f59fc105b15bbab6fce4802d6d585580e/ql0.js#L89