### PR TITLE
use monotonic-timestamp in create()

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -32,11 +32,14 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+      - uses: pnpm/action-setup@v2.2.2
+        with:
+          version: 7
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
-      - run: npm install
+      - run: pnpm install
       - name: npm test
         run: DEBUG=ssb:db2,ssb:db2:* npm test
 

--- a/core.js
+++ b/core.js
@@ -11,6 +11,7 @@ const Debug = require('debug')
 const clarify = require('clarify-error')
 const multicb = require('multicb')
 const mutexify = require('mutexify')
+const newTimestamp = require('monotonic-timestamp')
 const push = require('push-stream')
 const Notify = require('pull-notify')
 const pull = require('pull-stream')
@@ -636,15 +637,16 @@ exports.init = function (sbot, config) {
     await onceWhenPromise(stateFeedsReady, (ready) => ready === true)
 
     // Create full opts:
+    const timestamp = newTimestamp()
     const provisionalNativeMsg = feedFormat.newNativeMsg({
-      timestamp: Date.now(),
+      timestamp,
       ...opts,
       previous: null,
       keys,
     })
     const feedId = feedFormat.getFeedId(provisionalNativeMsg)
     const previous = state.getAsKV(feedId, feedFormat)
-    const fullOpts = { timestamp: Date.now(), ...opts, previous, keys, hmacKey }
+    const fullOpts = { timestamp, ...opts, previous, keys, hmacKey }
 
     // If opts ask for encryption, encrypt and put ciphertext in opts.content
     const recps = fullOpts.recps || fullOpts.content.recps

--- a/log.js
+++ b/log.js
@@ -5,6 +5,7 @@
 const OffsetLog = require('async-append-only-log')
 const bipf = require('bipf')
 const TooHot = require('too-hot')
+const newTimestamp = require('monotonic-timestamp')
 const { BLOCK_SIZE, newLogPath, tooHotOpts } = require('./defaults')
 
 const BIPF_AUTHOR = bipf.allocAndEncode('author')
@@ -37,7 +38,7 @@ module.exports = function (dir, config, privateIndex, db) {
     const kvt = {
       key,
       value,
-      timestamp: Date.now(),
+      timestamp: newTimestamp(),
     }
     if (feedId !== value.author) kvt.feed = feedId
     const recBuffer = bipf.allocAndEncode(kvt)
@@ -62,11 +63,12 @@ module.exports = function (dir, config, privateIndex, db) {
     let recBuffers = []
     let kvts = []
 
+    const timestamp = newTimestamp()
     for (let i = 0; i < keys.length; ++i) {
       const kvt = {
         key: keys[i],
         value: values[i],
-        timestamp: Date.now(),
+        timestamp,
       }
       const recBuffer = bipf.allocAndEncode(kvt)
       recBuffers.push(recBuffer)

--- a/log.js
+++ b/log.js
@@ -63,12 +63,11 @@ module.exports = function (dir, config, privateIndex, db) {
     let recBuffers = []
     let kvts = []
 
-    const timestamp = newTimestamp()
     for (let i = 0; i < keys.length; ++i) {
       const kvt = {
         key: keys[i],
         value: values[i],
-        timestamp,
+        timestamp: newTimestamp(),
       }
       const recBuffer = bipf.allocAndEncode(kvt)
       recBuffers.push(recBuffer)

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "level-codec": "^9.0.2",
     "lodash.debounce": "^4.0.8",
     "mkdirp": "^1.0.4",
+    "monotonic-timestamp": "~0.0.9",
     "multicb": "1.2.2",
     "mutexify": "^1.3.1",
     "obz": "^1.1.0",

--- a/test/createLogStream.js
+++ b/test/createLogStream.js
@@ -78,7 +78,7 @@ test('createLogStream (live)', function (t) {
     sbot.createLogStream({ live: true }),
     pull.drain(function (m) {
       if (m.sync) return t.pass('{sync: true}')
-      t.true(m.timestamp > ts)
+      t.true(m.timestamp > ts, `msg timestamp ${m.timestamp} > ${ts}`)
       t.equal(m.value.content.type, 'msg')
       t.end()
       return false // abort the pull.drain


### PR DESCRIPTION
`ssb-db` and `ssb-validate` both use `monotonic-timestamp` to avoid the problem where two consecutive calls of `Date.now()` would give the same number. In our case this would help so we can avoid the `Date.now() + 1`, `Date.now() + 2` hacks. I do think that the async-await we use in `create()` already guarantees that `Date.now()` will be different (I was unable to create a 1st :x: 2nd :heavy_check_mark: test), but it makes sense to anyway use `monotonic-timestamp` to be sure we never bump into this problem.