### PR TITLE
add logStats() API

### DIFF
--- a/README.md
+++ b/README.md
@@ -588,6 +588,11 @@ at runtime and that changes what messages can be decrypted. Calling
 this function is needed after adding a new key. The function can be
 called multiple times safely.
 
+### logStats(cb)
+
+Use [async-append-only-log]'s `stats` method to get information on how many
+bytes are used by messages in the log, and how many bytes are zero-filled.
+
 ### prepare(operation, cb)
 
 Use [JITDB's prepare](https://github.com/ssb-ngi-pointer/jitdb/#prepareoperation-cb) method to warm up a JIT index.
@@ -706,6 +711,7 @@ all [jitdb operators]
 - isDecrypted
 
 [ssb-db]: https://github.com/ssbc/ssb-db/
+[async-append-only-log]: https://github.com/ssbc/async-append-only-log/
 [bipf]: https://github.com/ssbc/bipf/
 [jitdb]: https://github.com/ssb-ngi-pointer/jitdb/
 [bendy butt]: https://github.com/ssb-ngi-pointer/ssb-bendy-butt

--- a/core.js
+++ b/core.js
@@ -68,6 +68,7 @@ exports.manifest = {
   addOOOBatch: 'async',
   getStatus: 'sync',
   compact: 'async',
+  logStats: 'async',
   indexingProgress: 'source',
   compactionProgress: 'source',
 
@@ -1080,6 +1081,7 @@ exports.init = function (sbot, config) {
     onMsgAdded,
     compact,
     reindexEncrypted,
+    logStats: log.stats,
     indexingProgress: () => indexingProgress.listen(),
     compactionProgress: () => compactionProgress.listen(),
 

--- a/test/basic.js
+++ b/test/basic.js
@@ -167,6 +167,17 @@ test('delete single msg', (t) => {
   })
 })
 
+test('logStats()', (t) => {
+  db.logStats((err, stats) => {
+    t.error(err, 'no err')
+    t.equals(stats.totalCount, 34)
+    t.equals(stats.totalBytes, 13312)
+    t.equals(stats.deletedCount, 1)
+    t.equals(stats.deletedBytes, 405)
+    t.end()
+  })
+})
+
 test('deleteFeed', (t) => {
   const post = { type: 'post', text: 'Testing!' }
   const post2 = { type: 'post', text: 'Testing 2!' }


### PR DESCRIPTION
This is just because I want to avoid `getLog()` as a public API (I'm trying to reduce the amount of APIs in each library, this gives us more implementation flexibility), but we need a way of calling the `stats` method in AAOL.