### PR TITLE
use setTimeout in deleteFeed

### DIFF
--- a/core.js
+++ b/core.js
@@ -735,7 +735,9 @@ exports.init = function (sbot, config) {
 
             push(
               push.values(offsets),
-              push.asyncMap(log.del),
+              push.asyncMap((offset, cb) => {
+                setTimeout(() => log.del(offset, cb))
+              }),
               push.collect((err) => {
                 // prettier-ignore
                 if (err) return cb(clarify(err, 'deleteFeed() failed for feed ' + feedId))


### PR DESCRIPTION
This PR is just a conversation starter.

In Manyverse I'm running a lot of `deleteFeed` (for all the feeds at negative hops distance), and some of the feeds are large (one of them has 17MB worth of messages on the log).

I noticed that if I try to use the app while `deleteFeed` is running for a large feed, the UI freezes entirely, and then goes back to normal after ~6sec. Ignore the fact that the Electron main (where ssb-db2 runs) should be a different thread to the Electron renderer (where the HTML is), so one thread **should not** affect the other, but :man_shrugging: . 

Anyway, what seems to be happening is that `push-stream` with `push.values()` runs *synchronously* (it has a `while` loop internally), and even though the `push.asyncMap` has the word "async", quite often `log.del` runs *synchronously* too, because of block caches in AAOL. Only when there is a cache miss in AAOL will this pipeline have a "break" for actual async I/O with the filesystem.

I made this experiment with `setTimeout` and it clearly helped the UI to not freeze. Obviously this made the total time longer for `deleteFeed` to complete. Before: ~6s for one heavy feed, after: ~50s for one heavy feed. But for my purposes it's more important that deletes don't freeze the UI than it is to delete ASAP. I **know** other people will have different priorities and it's important that deleteFeed can run as fast as it can.

In fact, there are two important parts here:

- `query(where(author(feedId)), asOffsets(), toCallback`)
- `push-stream` pipeline for `log.del`

The 2nd is much heavier than the first, but *sometimes*, if there is a huge amount of messages in the 1st part, the app UI also freezes. Ideally it would be good to solve that one too, which is a jitdb responsibility, but for my purposes, the 1st part freezing is not as bad as the 2nd part freezing.

Thoughts?