### PR TITLE
add reset() API

### DIFF
--- a/README.md
+++ b/README.md
@@ -623,6 +623,11 @@ If `encryptionFormat` conforms to the [ssb-encryption-format] spec, then this
 method will install the `encryptionFormat` in this database instance, meaning
 that you can now encrypt and decrypt messages using that encryption format.
 
+### reset(cb)
+
+Force all indexese to be rebuilt. Use this as a last resort if you suspect that
+the indexes are corrupted.
+
 ## Configuration
 
 You can use ssb-config parameters to configure some aspects of ssb-db2:

--- a/core.js
+++ b/core.js
@@ -71,6 +71,7 @@ exports.manifest = {
   logStats: 'async',
   indexingProgress: 'source',
   compactionProgress: 'source',
+  reset: 'async',
 
   // `query` should be `sync`, but secret-stack is automagically converting it
   // to async because of secret-stack/utils.js#hookOptionalCB. Eventually we
@@ -1051,6 +1052,18 @@ exports.init = function (sbot, config) {
     }
   })
 
+  function reset(cb) {
+    stopUpdatingIndexes()
+    const done = multicb({ pluck: 1 })
+    status.reset()
+    resetAllIndexes(done())
+    privateIndex.reset(done())
+    done(() => {
+      resumeUpdatingIndexes()
+      cb()
+    })
+  }
+
   function publish() {
     // prettier-ignore
     throw new Error('publish() not installed, you should .use(require("ssb-db2/compat/publish"))')
@@ -1084,6 +1097,7 @@ exports.init = function (sbot, config) {
     logStats: log.stats,
     indexingProgress: () => indexingProgress.listen(),
     compactionProgress: () => compactionProgress.listen(),
+    reset,
 
     // needed primarily internally by other plugins in this project:
     publish,


### PR DESCRIPTION
We have this API hacked in Manyverse already, would be nice to upstream it in ssb-db2: https://github.com/staltz/manyverse/blob/b0f5f4b17e85ac6d2777bd581dd084fbf97f5b59/src/backend/patches/ssb-db2%2B4.2.1.patch