### PR TITLE
add getIndexingActive() API

### DIFF
--- a/core.js
+++ b/core.js
@@ -1090,6 +1090,7 @@ exports.init = function (sbot, config) {
     addOOO,
     addOOOBatch,
     getStatus: () => status.obv,
+    getIndexingActive: () => indexingActive,
     operators,
     onMsgAdded,
     compact,


### PR DESCRIPTION
We need this for pausing the ssb-friends / ssb-replication-scheduler integration, because indexingActive is triggered *right before* log.stream to update the indexes, and we need this "right before" behavior, that `status` doesn't give us.

I haven't thought out this API that well, I think in the future we could find a more developer friendly way of doing this.