### PR TITLE
test streaming and decrypting records

### DIFF
--- a/core.js
+++ b/core.js
@@ -787,7 +787,7 @@ exports.init = function (sbot, config) {
       debug('updateIndexes() called while another one is in progress')
       return
     }
-    const shouldDecrypt = true
+    const updatePrivateIndex = true
     const start = Date.now()
 
     const indexesArr = Object.values(indexes)
@@ -799,7 +799,7 @@ exports.init = function (sbot, config) {
     debug(`lowest offset for all indexes is ${lowestOffset}`)
 
     indexingActive.set(indexingActive.value + 1)
-    const sourceOld = log.stream({ gt: lowestOffset, shouldDecrypt })
+    const sourceOld = log.stream({ gt: lowestOffset, updatePrivateIndex })
     abortLogStreamForIndexes = sourceOld.abort.bind(sourceOld)
     sourceOld.pipe({
       paused: false,
@@ -819,7 +819,7 @@ exports.init = function (sbot, config) {
           indexingActive.set(indexingActive.value - 1)
           debug('updateIndexes() live streaming')
           const gt = indexes['base'].offset.value
-          const sourceLive = log.stream({ gt, live: true, shouldDecrypt })
+          const sourceLive = log.stream({ gt, live: true, updatePrivateIndex })
           abortLogStreamForIndexes = sourceLive.abort.bind(sourceLive)
           sourceLive.pipe({
             paused: false,

--- a/indexes/private.js
+++ b/indexes/private.js
@@ -165,7 +165,7 @@ module.exports = function (dir, sbot, config) {
     return { offset: record.offset, value: newRecBuffer }
   }
 
-  function decrypt(record, streaming) {
+  function decrypt(record, updatingPrivateIndex) {
     const recOffset = record.offset
     const recBuffer = record.value
     if (!recBuffer) return record
@@ -180,8 +180,8 @@ module.exports = function (dir, sbot, config) {
       if (!decryptedRecord) return record
 
       return decryptedRecord
-    } else if (recOffset > latestOffset.value || !streaming) {
-      if (streaming) latestOffset.set(recOffset)
+    } else if (recOffset > latestOffset.value || !updatingPrivateIndex) {
+      if (updatingPrivateIndex) latestOffset.set(recOffset)
 
       const pValue = bipf.seekKey2(recBuffer, 0, BIPF_VALUE, 0)
       if (pValue < 0) return record
@@ -203,7 +203,7 @@ module.exports = function (dir, sbot, config) {
         if (declaredTimestamp < startDecryptBox1) return record
       }
 
-      if (streaming) {
+      if (updatingPrivateIndex) {
         const encryptedIdx = encryptedIdxMap.get(encryptionFormat.name)
         encryptedIdx.insert(recOffset)
       }
@@ -214,7 +214,7 @@ module.exports = function (dir, sbot, config) {
       decryptedIdx.insert(recOffset)
       encryptedIdxMap.get(encryptionFormat.name).remove(recOffset)
 
-      if (!streaming) saveIndexes(() => {})
+      if (!updatingPrivateIndex) saveIndexes(() => {})
       return decryptedRecord
     } else {
       return record

--- a/log.js
+++ b/log.js
@@ -136,7 +136,7 @@ module.exports = function (dir, config, privateIndex, db) {
   // and to decrypt the msg
   const originalStream = log.stream
   log.stream = function (opts) {
-    const shouldDecrypt = opts.decrypt === false ? false : true
+    const shouldDecrypt = !!opts.shouldDecrypt
     const tooHot = config.db2.maxCpu ? TooHot(tooHotOpts(config)) : () => false
     const s = originalStream(opts)
     const originalPipe = s.pipe.bind(s)

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "operators/*.js"
   ],
   "dependencies": {
-    "async-append-only-log": "^4.3.2",
+    "async-append-only-log": "^4.3.7",
     "atomic-file-rw": "^0.3.0",
     "binary-search-bounds": "^2.0.4",
     "bipf": "^1.9.0",

--- a/test/stream-decrypting.js
+++ b/test/stream-decrypting.js
@@ -1,0 +1,130 @@
+// SPDX-FileCopyrightText: 2022 Anders Rune Jensen
+//
+// SPDX-License-Identifier: Unlicense
+
+const pull = require('pull-stream')
+const test = require('tape')
+const ssbKeys = require('ssb-keys')
+const path = require('path')
+const rimraf = require('rimraf')
+const mkdirp = require('mkdirp')
+const pify = require('util').promisify
+const SecretStack = require('secret-stack')
+const bipf = require('bipf')
+const caps = require('ssb-caps')
+const Plugin = require('../indexes/plugin')
+const { live, toPullStream } = require('../operators')
+
+test('log.stream decrypting', async (t) => {
+  t.timeoutAfter(20e3)
+
+  const dir = '/tmp/ssb-db2-stream-decrypting'
+
+  rimraf.sync(dir)
+  mkdirp.sync(dir)
+
+  const keys = ssbKeys.loadOrCreateSync(path.join(dir, 'secret'))
+  const sbot = SecretStack({ appKey: caps.shs })
+    .use(require('../'))
+    .call(null, {
+      keys,
+      path: dir,
+    })
+
+  // Purposefully slow down log.getBlock so that we can simulate race conditions
+  const log = sbot.db.getLog()
+  const originalGetBlock = log.getBlock
+  log.getBlock = function getBlock(offset, cb) {
+    // Speed up lookups at the end of the log
+    const period = offset > log.since.value * 0.9 ? 0 : 200
+    setTimeout(originalGetBlock, period, offset, cb)
+  }
+
+  let bingoCount = 0
+  sbot.db.registerIndex(
+    class TestPlugin extends Plugin {
+      constructor(log, dir) {
+        super(log, dir, 'testPlugin', 1)
+      }
+
+      processRecord(record, seq, pValue) {
+        const buf = record.value
+        const pValueContent = bipf.seekKey(buf, pValue, 'content')
+        if (pValueContent < 0) return
+        const pValueContentType = bipf.seekKey(buf, pValueContent, 'type')
+        if (pValueContentType < 0) return
+        const type = bipf.decode(buf, pValueContentType)
+        if (type === 'bingo') {
+          bingoCount += 1
+        }
+      }
+    }
+  )
+
+  const TOTAL = 400
+  const DELETES = 40
+  const msgKeys = []
+  for (let i = 0; i < TOTAL; i += 1) {
+    const msg = await pify(sbot.db.publish)({ type: 'post', text: `hi ${i}` })
+    msgKeys.push(msg.key)
+  }
+  t.pass('published messages')
+
+  await pify(sbot.db.create)({
+    keys,
+    content: { type: 'bingo', text: 'private!' },
+    recps: [sbot.id],
+  })
+  t.pass('published a private message')
+
+  await pify(sbot.db.create)({
+    keys,
+    content: { type: 'post', text: 'hello' },
+  })
+  t.pass('published a public message')
+
+  await pify(sbot.db.onDrain)('testPlugin')
+  t.equal(bingoCount, 1, 'processed private record')
+
+  let foundLatestMsg = false
+  pull(
+    sbot.db.query(live({ old: false }), toPullStream()),
+    pull.drain((msg) => {
+      if (msg.value.content.text === 'latest') {
+        foundLatestMsg = true
+      }
+    })
+  )
+
+  for (let i = 0; i < DELETES; i += 1) {
+    await pify(sbot.db.del)(msgKeys[i])
+  }
+  await pify(sbot.db.getLog().onDeletesFlushed)()
+  t.pass('deleted ' + DELETES + ' messages')
+
+  await pify(sbot.db.compact)()
+  t.pass('compacted')
+
+  await pify(sbot.db.create)({
+    content: { type: 'post', text: 'latest' },
+  })
+  t.pass('published a new message')
+
+  await pify(sbot.db.onDrain)('testPlugin')
+  t.pass('reindexed')
+
+  await new Promise((resolve) => {
+    const interval = setInterval(() => {
+      if (foundLatestMsg) {
+        clearInterval(interval)
+        resolve()
+      }
+    }, 200)
+  })
+
+  t.equal(bingoCount, 2, 're-processed private record')
+
+  t.pass('lets close up')
+  await pify(sbot.close)(true)
+  t.end()
+})


### PR DESCRIPTION
## Context

https://github.com/ssbc/ssb-replication-scheduler/issues/3

## Problem

In privateIndex we use `streaming === true` to update the latestOffset, but this is troublesome if there is some live stream which takes the latest record in the log, because it'll update privateIndex's latestOffset and then when reindexing all previous records, we won't attempt to decrypt them because they aren't in the decrypted list and neither does the `recOffset > latestOffset` pass.

## Solution

We should really only have one log.stream that is responsible for updating the private index. I elect the "leveldb log.stream" to be the only stream that can do that, thus we pass a `opts.shouldDecrypt = true` only for the core log.stream.

At the same time, this required fixing how log.stream was aborted. There was a race condition or something like that. We need to set the reference to log.stream.abort **before** we start draining the log.stream.

1st :x: 2nd :heavy_check_mark: 
