### PR TITLE
No encryption

### DIFF
--- a/core.js
+++ b/core.js
@@ -641,7 +641,11 @@ exports.init = function (sbot, config) {
     // prettier-ignore
     if (!feedFormat.isAuthor(keys.id)) return cb(new Error(`create() failed because keys.id ${keys.id} is not a valid author for feed format ${feedFormat.name}`))
     // prettier-ignore
-    if (!encryptionFormat) return cb(new Error('create() does not support encryption format ' + opts.encryptionFormat))
+    if (!encryptionFormat) {
+      if (opts.recps || opts.content.recps) {
+        return cb(new Error('create() does not support encryption format ' + opts.encryptionFormat))
+      }
+    }
 
     if (!opts.content) return cb(new Error('create() requires a `content`'))
 

--- a/test/minimal-db2.js
+++ b/test/minimal-db2.js
@@ -1,0 +1,35 @@
+const test = require('tape')
+const ssbKeys = require('ssb-keys')
+const rimraf = require('rimraf')
+const SecretStack = require('secret-stack')
+const caps = require('ssb-caps')
+
+test('minimal db2 (no encryption)', t => {
+  const dir = '/tmp/ssb-db2-minimal-create'
+  rimraf.sync(dir)
+
+  const keys = ssbKeys.generate()
+
+  const stack = SecretStack({ appKey: caps.shs })
+    .use(require('../core'))
+    .use(require('ssb-classic'))
+    // .use(require('ssb-box'))
+    // .use(require('ssb-box2'))
+    // .use(require('../compat/publish'))
+    // .use(require('../compat/post'))
+    // .use(require('../migrate'))
+
+  const ssb = stack({
+    path: dir,
+    keys
+  })
+
+  ssb.db.create({
+    content: { type: 'boop' },
+    keys
+  }, (err, msg) => {
+    t.error(err, 'published message')
+
+    ssb.close(true, t.end)
+  })
+})

--- a/test/minimal-db2.js
+++ b/test/minimal-db2.js
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2022 Mix Irving
+//
+// SPDX-License-Identifier: Unlicense
+
 const test = require('tape')
 const ssbKeys = require('ssb-keys')
 const rimraf = require('rimraf')
@@ -13,11 +17,6 @@ test('minimal db2 (no encryption)', t => {
   const stack = SecretStack({ appKey: caps.shs })
     .use(require('../core'))
     .use(require('ssb-classic'))
-    // .use(require('ssb-box'))
-    // .use(require('ssb-box2'))
-    // .use(require('../compat/publish'))
-    // .use(require('../compat/post'))
-    // .use(require('../migrate'))
 
   const ssb = stack({
     path: dir,
@@ -30,6 +29,13 @@ test('minimal db2 (no encryption)', t => {
   }, (err, msg) => {
     t.error(err, 'published message')
 
-    ssb.close(true, t.end)
+    ssb.db.create({
+      content: { type: 'boop', recps: [ssb.id] },
+      keys
+    }, (err) => {
+      t.match(err.message, /does not support encryption format undefined/, 'still errors on unencrypted messages')
+
+      ssb.close(true, t.end)
+    })
   })
 })


### PR DESCRIPTION
**Problem**: building a peer which doesn't do any encryption, but may want to publish things. Removing encryption reduces load on this peer (running on cheap droplet). The current code fails, even if you're not encrypting anything.

**Solution**: added a test case for minimal setup, and patched code to make it pass