### PR TITLE
add tests for over-sized classic msgs, patch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 .vscode
 node_modules
 pnpm-lock.yaml
+package-lock.json
 coverage
 *~
 

--- a/core.js
+++ b/core.js
@@ -653,12 +653,18 @@ exports.init = function (sbot, config) {
     await onceWhenPromise(stateFeedsReady, (ready) => ready === true)
 
     // Create full opts:
-    const provisionalNativeMsg = feedFormat.newNativeMsg({
-      timestamp: Date.now(),
-      ...opts,
-      previous: null,
-      keys,
-    })
+
+    let provisionalNativeMsg
+    try {
+      provisionalNativeMsg = feedFormat.newNativeMsg({
+        timestamp: Date.now(),
+        ...opts,
+        previous: null,
+        keys,
+      })
+    } catch (err) {
+      return cb(err)
+    }
     const feedId = feedFormat.getFeedId(provisionalNativeMsg)
     const previous = state.getAsKV(feedId, feedFormat)
     const fullOpts = { timestamp: Date.now(), ...opts, previous, keys, hmacKey }
@@ -688,7 +694,12 @@ exports.init = function (sbot, config) {
     }
 
     // Create the native message:
-    const nativeMsg = feedFormat.newNativeMsg(fullOpts)
+    let nativeMsg
+    try {
+      nativeMsg = feedFormat.newNativeMsg(fullOpts)
+    } catch (err) {
+      return cb(err)
+    }
     const msgId = feedFormat.getMsgId(nativeMsg)
     const msg = feedFormat.fromNativeMsg(nativeMsg, encoding)
     state.update(feedId, nativeMsg)

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "ssb-about-self": "^1.0.1",
     "ssb-box": "^1.0.0",
     "ssb-box2": "^2.0.2",
-    "ssb-classic": "ssbc/ssb-classic#validate_size",
+    "ssb-classic": "^1.1.0",
     "ssb-keys": "^8.4.0",
     "ssb-ref": "^2.14.3",
     "ssb-uri2": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "ssb-about-self": "^1.0.1",
     "ssb-box": "^1.0.0",
     "ssb-box2": "^2.0.2",
-    "ssb-classic": "^1.0.3",
+    "ssb-classic": "ssbc/ssb-classic#validate_size",
     "ssb-keys": "^8.4.0",
     "ssb-ref": "^2.14.3",
     "ssb-uri2": "^2.0.0",

--- a/test/create.js
+++ b/test/create.js
@@ -60,30 +60,29 @@ test('create() classic', (t) => {
 test('create() classic "too big"', (t) => {
   const content = {
     type: 'post',
-    text: Array(10000).fill('!').join('')
+    text: Array(10000).fill('!').join(''),
   }
-  db.create(
-    { feedFormat: 'classic', content, },
-    (err, msg) => {
+  db.create({ feedFormat: 'classic', content }, (err, msg) => {
+    const comment = 'should error when content > 8kb'
+    if (!err) t.fail(comment)
+    else t.match(err.message, /create() failed/, comment)
+
+    const content = {
+      type: 'post',
+      text: Array(8192 - 114)
+        .fill('!')
+        .join(''),
+      recps: [sbot.id],
+    }
+
+    db.create({ feedFormat: 'classic', content }, (err) => {
       const comment = 'should error when content > 8kb'
       if (!err) t.fail(comment)
-      else t.match(err.message, /content must be at most 8192/, comment)
+      else t.match(err.message, /create() failed/, comment)
 
-      const content = {
-        type: 'post',
-        text: Array(8192 - 114).fill('!').join(''),
-        recps: [sbot.id]
-      }
-
-      db.create({ feedFormat: 'classic', content }, err => {
-        const comment = 'should error when content > 8kb'
-        if (!err) t.fail(comment)
-        else t.match(err.message, /content must be at most 8192/, comment)
-
-        t.end()
-      })
-    }
-  )
+      t.end()
+    })
+  })
 })
 
 test('create() classic box', (t) => {

--- a/test/create.js
+++ b/test/create.js
@@ -67,7 +67,7 @@ test('create() classic "too big"', (t) => {
     (err, msg) => {
       const comment = 'should error when content > 8kb'
       if (!err) t.fail(comment)
-      else t.match(err.message, /content must be less than 8192/, comment)
+      else t.match(err.message, /content must be at most 8192/, comment)
 
       const content = {
         type: 'post',
@@ -78,7 +78,7 @@ test('create() classic "too big"', (t) => {
       db.create({ feedFormat: 'classic', content }, err => {
         const comment = 'should error when content > 8kb'
         if (!err) t.fail(comment)
-        else t.match(err.message, /content must be less than 8192/, comment)
+        else t.match(err.message, /content must be at most 8192/, comment)
 
         t.end()
       })

--- a/test/create.js
+++ b/test/create.js
@@ -65,7 +65,7 @@ test('create() classic "too big"', (t) => {
   db.create({ feedFormat: 'classic', content }, (err, msg) => {
     const comment = 'should error when content > 8kb'
     if (!err) t.fail(comment)
-    else t.match(err.message, /create() failed/, comment)
+    else t.match(err.message, /create\(\) failed/, comment)
 
     const content = {
       type: 'post',
@@ -78,7 +78,7 @@ test('create() classic "too big"', (t) => {
     db.create({ feedFormat: 'classic', content }, (err) => {
       const comment = 'should error when content > 8kb'
       if (!err) t.fail(comment)
-      else t.match(err.message, /create() failed/, comment)
+      else t.match(err.message, /create\(\) failed/, comment)
 
       t.end()
     })

--- a/test/create.js
+++ b/test/create.js
@@ -57,6 +57,35 @@ test('create() classic', (t) => {
   )
 })
 
+test('create() classic "too big"', (t) => {
+  const content = {
+    type: 'post',
+    text: Array(10000).fill('!').join('')
+  }
+  db.create(
+    { feedFormat: 'classic', content, },
+    (err, msg) => {
+      const comment = 'should error when content > 8kb'
+      if (!err) t.fail(comment)
+      else t.match(err.message, /content must be less than 8192/, comment)
+
+      const content = {
+        type: 'post',
+        text: Array(8192 - 114).fill('!').join(''),
+        recps: [sbot.id]
+      }
+
+      db.create({ feedFormat: 'classic', content }, err => {
+        const comment = 'should error when content > 8kb'
+        if (!err) t.fail(comment)
+        else t.match(err.message, /content must be less than 8192/, comment)
+
+        t.end()
+      })
+    }
+  )
+})
+
 test('create() classic box', (t) => {
   db.create(
     {


### PR DESCRIPTION
Leans on https://github.com/ssbc/ssb-classic/pull/2

This adds tests for over-sized classic messages (plaintext + encrypted).

TODO:
- [x] install `ssb-classic` correctly once that's released