### PR TITLE
fix annoying encryptionFormat bug

### DIFF
--- a/core.js
+++ b/core.js
@@ -641,8 +641,8 @@ exports.init = function (sbot, config) {
     // prettier-ignore
     if (!feedFormat.isAuthor(keys.id)) return cb(new Error(`create() failed because keys.id ${keys.id} is not a valid author for feed format ${feedFormat.name}`))
     // prettier-ignore
-    if (!encryptionFormat) {
-      if (opts.recps || opts.content.recps) {
+    if (opts.recps || opts.content.recps) {
+      if (!encryptionFormat) {
         return cb(new Error('create() does not support encryption format ' + opts.encryptionFormat))
       }
     }


### PR DESCRIPTION
I want to be able to just use box2, but when i took out box1 all my tests for encrypted messages were complaining.
ANNOYING AS SHIT

This inversion fixes it - i.e. only be fretting about encryptionFormat being present or not IF I'm possibly trying to encrrypt