### PR TITLE
correctly wait for private index loading

### DIFF
--- a/indexes/private.js
+++ b/indexes/private.js
@@ -45,9 +45,11 @@ module.exports = function (dir, sbot, config) {
       }
     }
 
-    decryptedIdx.loadFile(err => done()(null, err))
+    const loadedDecrypted = done()
+    decryptedIdx.loadFile(err => loadedDecrypted(null, err))
     for (const idx of encryptedIdxMap.values()) {
-      idx.loadFile(err => done()(null, err))
+      const loadedEncrypted = done()
+      idx.loadFile(err => loadedEncrypted(null, err))
     }
 
     done((criticalError, results) => {


### PR DESCRIPTION
## Context

https://github.com/ssbc/ssb-ebt/issues/77

## Problem

multicb is a bit tricky to use. It can generate CBs with `done()`, but if you call `done(() => {...` then it will **wait** for all the generated CBs to get called.

Problem here is that we were generating the CBs too late, we were generating them *after* the file had loaded, which meant that when it proceeded to `done((criticalError, results) => {` it was NOT waiting for files to be loaded, and thus we would always get offset `-1` for these indexes, which would cause a full rebuild of them.

## Solution

Generate the multicb callbacks synchronously, before waiting for them.

Unfortunately no tests added because I'm confused as to how to test this. We don't have a proper hook to catch the moment when the private index is loaded. `onDrain` isn't that because it's going to wait for the private index to be *built*. And the base index and private indexes are built eagerly ASAP, so :shrug: 