### PR TITLE
private index updates the status

### DIFF
--- a/core.js
+++ b/core.js
@@ -118,6 +118,7 @@ exports.init = function (sbot, config) {
     })
   })
 
+  privateIndex.latestOffset((offset) => status.updateIndex('private', offset))
   registerIndex(makeBaseIndex(privateIndex))
   registerIndex(KeysIndex)
 
@@ -802,7 +803,7 @@ exports.init = function (sbot, config) {
 
     if (indexes[index.name]) throw 'Index already exists'
 
-    index.offset((o) => status.updateIndex(index.name, o))
+    index.offset((offset) => status.updateIndex(index.name, offset))
 
     indexes[index.name] = index
   }

--- a/test/private-without-query.js
+++ b/test/private-without-query.js
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText: 2021 Anders Rune Jensen
+//
+// SPDX-License-Identifier: Unlicense
+
+const test = require('tape')
+const ssbKeys = require('ssb-keys')
+const path = require('path')
+const rimraf = require('rimraf')
+const mkdirp = require('mkdirp')
+const SecretStack = require('secret-stack')
+const caps = require('ssb-caps')
+
+const dir = '/tmp/ssb-db2-private-without-query'
+
+rimraf.sync(dir)
+mkdirp.sync(dir)
+
+const keys = ssbKeys.loadOrCreateSync(path.join(dir, 'secret'))
+
+let sbot = SecretStack({ appKey: caps.shs }).use(require('../')).call(null, {
+  keys,
+  path: dir,
+})
+const db = sbot.db
+
+test('private index shows in status', (t) => {
+  const content = { type: 'post', text: 'super secret', recps: [keys.id] }
+
+  db.create({ content }, (err, privateMsg) => {
+    t.error(err, 'no err')
+
+    db.onDrain(() => {
+      const stats = db.getStatus().value
+      t.equal(stats.indexes.private, 0, 'status indexes.private exists')
+      t.end()
+    })
+  })
+})
+
+test('teardown', (t) => {
+  sbot.close(t.end)
+})


### PR DESCRIPTION
## Context

https://github.com/ssbc/ssb-ebt/issues/77

When the private index *alone* was being rebuilt, no other index, then Manyverse would not show a progress bar.

## Problem

Private index is actually not included in the `status` object that is used for calculating indexing progress.

## Solution 

Now it is.

1st :x: 2nd :heavy_check_mark: 