### PR TITLE
Simplify deleteFeed

### DIFF
--- a/core.js
+++ b/core.js
@@ -757,24 +757,15 @@ exports.init = function (sbot, config) {
       () => {
         if (!state.has(feedId)) return cb()
 
-        self.query(
-          where(author(feedId)),
-          asOffsets(),
-          toCallback((err, offsets) => {
+        pull(
+          self.query(where(author(feedId)), asOffsets(), toPullStream()),
+          pull.asyncMap(log.del),
+          pull.collect((err) => {
             // prettier-ignore
-            if (err) return cb(clarify(err, 'deleteFeed() failed to query jitdb for ' + feedId))
+            if (err) return cb(clarify(err, 'deleteFeed() failed for feed ' + feedId))
 
-            push(
-              push.values(offsets),
-              push.asyncMap(log.del),
-              push.collect((err) => {
-                // prettier-ignore
-                if (err) return cb(clarify(err, 'deleteFeed() failed for feed ' + feedId))
-
-                state.delete(feedId)
-                indexes.base.removeFeedFromLatest(feedId, cb)
-              })
-            )
+            state.delete(feedId)
+            indexes.base.removeFeedFromLatest(feedId, cb)
           })
         )
       }

--- a/core.js
+++ b/core.js
@@ -760,7 +760,7 @@ exports.init = function (sbot, config) {
         pull(
           self.query(where(author(feedId)), asOffsets(), toPullStream()),
           pull.asyncMap(log.del),
-          pull.collect((err) => {
+          pull.onEnd((err) => {
             // prettier-ignore
             if (err) return cb(clarify(err, 'deleteFeed() failed for feed ' + feedId))
 

--- a/core.js
+++ b/core.js
@@ -48,6 +48,7 @@ const {
   asOffsets,
   isEncrypted,
   toCallback,
+  batch,
   toPullStream,
 } = operators
 
@@ -758,7 +759,12 @@ exports.init = function (sbot, config) {
         if (!state.has(feedId)) return cb()
 
         pull(
-          self.query(where(author(feedId)), asOffsets(), toPullStream()),
+          self.query(
+            where(author(feedId)),
+            asOffsets(),
+            batch(1000),
+            toPullStream()
+          ),
           pull.asyncMap(log.del),
           pull.onEnd((err) => {
             // prettier-ignore


### PR DESCRIPTION
This fixes #402. No need to load up all the offsets into memory if we just delete all of them anyway.