### PR TITLE
Recommend toPullStream over toCallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -467,7 +467,7 @@ operators:
 - The `to____()` part, determining how you want the messages delivered, e.g.
   - `toCallback((err, msgs) => { })`
   - `toPromise()`
-  - `toPullStream()`
+  - `toPullStream()` **RECOMMENDED** with a `pull.drain` because it uses less memory
   - `toAsyncIter()`
 
 See [jitdb operators] and [operators/index.js] for a complete list of supported


### PR DESCRIPTION
Just a quick tip for other developers in the future, that toCallback can be an OOM footgun.