### PR TITLE
avoid pull.collect to avoid OOM crashes

### DIFF
--- a/compat/ebt.js
+++ b/compat/ebt.js
@@ -37,7 +37,7 @@ exports.init = function (sbot, config) {
               const { sequence } = value
               clock[authorId] = sequence
             }),
-            pull.collect((err) => {
+            pull.onEnd((err) => {
               // prettier-ignore
               if (err) return cb(clarify(err, 'ssb-db2 getVectorClock failed'))
               cb(null, clock)

--- a/core.js
+++ b/core.js
@@ -195,15 +195,17 @@ exports.init = function (sbot, config) {
             else cb(null, kvt)
           })
         }, 8),
-        pull.collect((err, kvts) => {
-          if (err) return console.error(clarify(err, 'loadStateFeeds failed'))
-          for (const kvt of kvts) {
+        pull.drain(
+          (kvt) => {
             state.updateFromKVT(PrivateIndex.reEncrypt(kvt))
+          },
+          (err) => {
+            if (err) return console.error(clarify(err, 'loadStateFeeds failed'))
+            debug('getAllLatest is done setting up initial validate state')
+            if (!stateFeedsReady.value) stateFeedsReady.set(true)
+            if (cb) cb()
           }
-          debug('getAllLatest is done setting up initial validate state')
-          if (!stateFeedsReady.value) stateFeedsReady.set(true)
-          if (cb) cb()
-        })
+        )
       )
     })
   }


### PR DESCRIPTION
## Context

Out-of-memory crashes in Manyverse.

## Problem

`pull.collect` considered harmful for RAM usage, because it internally accumulates an array of all stream items.

## Solution

In a few cases, we don't strictly need `pull.collect`, and `pull.drain` / `pull.onEnd` are just fine.