### PR TITLE
Add decrypted api for for box2 decrypted messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -473,14 +473,18 @@ operators:
 See [jitdb operators] and [operators/index.js] for a complete list of supported
 operators.
 
-### decrypted
+### reindexed()
 
-A pull-stream source with newly decrypted values returned as full
-messages. JITDB doesn't have a concept of exactly what values are
-decrypted so a separate api is needed. This api can be combined with
-`where` to receive old values, live values or decrypted values. 
+A pull-stream source of newly decrypted reindexed values returned as
+full messages. Calling `reindexEncrypted` after adding a new box2 key
+will trigger new values in this stream.
 
-Example:
+This api can be combined with `where` to receive messages of a
+particular type no matter if they are existing, newly added or
+decrypted values.
+
+Example of getting existing post messages together with newly
+decrypted ones:
 
 ``` js
     const pull = require('pull-stream')
@@ -493,7 +497,7 @@ Example:
           toPullStream()
         ),
         pull(
-          sbot2.db.decrypted,
+          sbot2.db.reindexed(),
           pull.filter((msg) => {
             return msg.value.content.type === 'post'
           })

--- a/README.md
+++ b/README.md
@@ -602,6 +602,8 @@ at runtime and that changes what messages can be decrypted. Calling
 this function is needed after adding a new key. The function can be
 called multiple times safely.
 
+The decrypted values from this can be consumed using `reindexed`.
+
 ### logStats(cb)
 
 Use [async-append-only-log]'s `stats` method to get information on how many

--- a/README.md
+++ b/README.md
@@ -473,6 +473,40 @@ operators:
 See [jitdb operators] and [operators/index.js] for a complete list of supported
 operators.
 
+### decrypted
+
+A pull-stream source with newly decrypted values returned as full
+messages. JITDB doesn't have a concept of exactly what values are
+decrypted so a separate api is needed. This api can be combined with
+`where` to receive old values, live values or decrypted values. 
+
+Example:
+
+``` js
+    const pull = require('pull-stream')
+    const cat = require('pull-cat')
+
+    pull(
+      cat([
+        sbot2.db.query(
+          where(type('post')),
+          toPullStream()
+        ),
+        pull(
+          sbot2.db.decrypted,
+          pull.filter((msg) => {
+            return msg.value.content.type === 'post'
+          })
+        )
+      ]),
+      pull.drain(
+        (result) => {
+           console.log("got a new post", result.value)
+        }
+      )
+    )
+```
+
 ### add(nativeMsg, cb)
 
 Validate and add a message to the database. The callback will the (possible)

--- a/test/query-decrypted-box2.js
+++ b/test/query-decrypted-box2.js
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2022 Anders Rune Jensen
+//
+// SPDX-License-Identifier: Unlicense
+
 const test = require('tape')
 const ssbKeys = require('ssb-keys')
 const path = require('path')

--- a/test/query-decrypted-box2.js
+++ b/test/query-decrypted-box2.js
@@ -11,7 +11,6 @@ const SecretStack = require('secret-stack')
 const caps = require('ssb-caps')
 const ssbUri = require('ssb-uri2')
 const pull = require('pull-stream')
-const cat = require('pull-cat')
 const fs = require('fs')
 const {
   where,
@@ -64,18 +63,10 @@ test('decrypted api contains newly decrypted box2 messages', (t) => {
 
     // setup decrypted handler
     pull(
-      cat([
-        sbot2.db.query(
-          where(type('post')),
-          toPullStream()
-        ),
-        pull(
-          sbot2.db.decrypted,
-          pull.filter((msg) => {
-            return msg.value.content.type === 'post'
-          })
-        )
-      ]),
+      sbot2.db.reindexed(),
+      pull.filter((msg) => {
+        return msg.value.content.type === 'post'
+      }),
       pull.drain(
         (result) => {
           t.equal(result.value.content.text, 'Testing!')

--- a/test/query-live-handle-box2-decrypts.js
+++ b/test/query-live-handle-box2-decrypts.js
@@ -1,0 +1,99 @@
+const test = require('tape')
+const ssbKeys = require('ssb-keys')
+const path = require('path')
+const rimraf = require('rimraf')
+const mkdirp = require('mkdirp')
+const SecretStack = require('secret-stack')
+const caps = require('ssb-caps')
+const ssbUri = require('ssb-uri2')
+const pull = require('pull-stream')
+const fs = require('fs')
+const {
+  where,
+  type,
+  live,
+  toPullStream,
+  toCallback
+} = require('../operators')
+
+const dir = '/tmp/ssb-db2-query-live-handle-box2-decrypts'
+rimraf.sync(dir)
+mkdirp.sync(dir)
+
+const dir2 = '/tmp/ssb-db2-query-live-handle-box2-decrypts2'
+rimraf.sync(dir2)
+mkdirp.sync(dir2)
+
+test('live query() contains decrypted box2 messages', (t) => {
+  const keys = ssbKeys.loadOrCreateSync(path.join(dir, 'secret'))
+  const sbot = SecretStack({ appKey: caps.shs })
+    .use(require('../'))
+    .call(null, { keys, path: dir })
+
+  const testkey = Buffer.from(
+    '30720d8f9cbf37f6d7062826f6decac93e308060a8aaaa77e6a4747f40ee1a76',
+    'hex'
+  )
+  const groupId = ssbUri.compose({
+    type: 'identity',
+    format: 'group',
+    data: '-oaWWDs8g73EZFUMfW37R_ULtFEjwKN_DczvdYihjbU=',
+  })
+  sbot.box2.addGroupInfo(groupId, { key: testkey })
+
+  const post = {
+    feedFormat: 'classic',
+    content: { type: 'post', text: 'Testing!' },
+    recps: [groupId],
+    encryptionFormat: 'box2',
+  }
+
+  sbot.db.create(post, (err, msgBoxed) => {
+    t.error(err, 'no err')
+    t.equal(typeof msgBoxed.value.content, 'string')
+    t.true(msgBoxed.value.content.endsWith('.box2'), '.box2')
+
+    const keys2 = ssbKeys.loadOrCreateSync(path.join(dir2, 'secret'))
+    const sbot2 = SecretStack({ appKey: caps.shs })
+      .use(require('../'))
+      .call(null, { keys: keys2, path: dir2 })
+
+    // setup live handler
+    pull(
+      sbot2.db.query(
+        where(type('post')),
+        live({ old: true }),
+        toPullStream()
+      ),
+      pull.drain(
+        (result) => {
+          t.equal(result.value.content.text, 'Testing!')
+          sbot.close(() => {
+            sbot2.close(t.end)
+          })
+        }
+      )
+    )
+
+    sbot2.db.add(msgBoxed.value, (err) => {
+      t.error(err, 'no err')
+
+      // make sure we have queries indexed before adding the key
+      pull(
+        sbot2.db.query(
+          where(type('post')),
+          toCallback((err, results) => {
+            t.error(err, 'no err')
+            t.equal(results.length, 0, 'no results')
+
+            sbot2.box2.addGroupInfo(groupId, { key: testkey })
+            sbot2.db.reindexEncrypted((err) => {
+              t.error(err, 'no err')
+              console.log("finished reindexing")
+            })
+          })
+        )
+      )
+    })
+  })
+})


### PR DESCRIPTION
This should fix #406

I went through a bit different solutions (see https://github.com/ssbc/jitdb/pull/236), but ended up with a new pull source api.

I considered doing this so the operators could be reused, but decided against that because the filtering is often pretty simple and this also shows people that doing a filter on the result is not that scary. Where this could also be useful is if you have something like do a rough filter on post but then filter the result only for specific stuff without creating an index in jitdb.
