### PR TITLE
Disable compaction in browser

### DIFF
--- a/core.js
+++ b/core.js
@@ -1070,6 +1070,9 @@ exports.init = function (sbot, config) {
 
     if (compacting.value !== !stats.done) compacting.set(!stats.done)
 
+    // fs sync not working in browser
+    if (typeof window !== 'undefined') return
+
     if (stats.done) {
       if (stats.sizeDiff > 0) {
         let resettingLevelIndexes = false


### PR DESCRIPTION
Related to https://github.com/ssbc/async-append-only-log/pull/91. I tried the minimum possible to get things running again. A better fix would of course be to allow compaction to run in the browser, but for now I'd like to get things running again. See https://github.com/arj03/ssb-browser-core/issues/71.