### PR TITLE
Test and fix post compat

### DIFF
--- a/compat/post.js
+++ b/compat/post.js
@@ -7,6 +7,7 @@ const Obv = require('obz')
 exports.init = function (sbot) {
   const post = Obv()
   sbot.db.post = post
+  sbot.post = post
   sbot.db.onMsgAdded((ev) => {
     post.set(ev.kvt)
   })

--- a/test/compat.js
+++ b/test/compat.js
@@ -109,6 +109,18 @@ test('keys', (t) => {
   t.end()
 })
 
+test('post', t=> {
+  sbot.post((msg)=> {
+    if (msg.value.content.text === 'post test') {
+      t.end()
+    }
+  })
+
+  sbot.publish({ type: 'test', text: 'post test'}, (err) => {
+    if (err) t.fail(err, 'failed publish for post')
+  })
+})
+
 test('teardown sbot', (t) => {
   sbot.close(true, () => t.end())
 })


### PR DESCRIPTION
For https://github.com/ssbc/ssb-tribes/pull/105

Trying to remove db1 completely from ssb-tribes, apparently some test runs replicate and that depends on `sbot.post`. But the compat plugin was only providing `sbot.db.post`. I also added a test.